### PR TITLE
Fix for E12 with EZABL (ANET_OEM)

### DIFF
--- a/TH3DUF/Configuration_backend.h
+++ b/TH3DUF/Configuration_backend.h
@@ -1018,6 +1018,7 @@
     #define FIX_MOUNTED_PROBE
        #define X_PROBE_OFFSET_FROM_EXTRUDER -38
        #define Y_PROBE_OFFSET_FROM_EXTRUDER -12
+       #define DISABLE_BOOT
     #endif
     #define INVERT_X_DIR false
     #define INVERT_Y_DIR true


### PR DESCRIPTION
In order for the firmware to upload to the E12 with the EZABL mount options uncommented, you need to also disable the bootscreen.

This likely works on the E10 as well, but I don't have one to test with.  E12 only for now.